### PR TITLE
Fix installation via devtools by specifying remote for olpsR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,3 +24,5 @@ Imports:
         Matrix,
         methods
 RoxygenNote: 7.1.0
+Remotes:
+  ngloe/olpsR


### PR DESCRIPTION
This PR solves an issues with installation due to depending on a package (`olpsR`) which is not available from CRAN.

I attempted to install the `de.bias.CCA` package following the instructions in the README, i.e., with
```
devtools::install_github("nilanjanalaha/de.bias.CCA")
```

After installing many dependencies, installation ultimately fails with error message:
```
ERROR: dependency ‘olpsR’ is not available for package ‘de.bias.cca’
* removing ‘/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/library/de.bias.cca’
Warning messages:
1: package ‘olpsR’ is not available for this version of R
```

I believe this is because the `olpsR` package, which is listed as a [dependency](https://github.com/nilanjanalaha/de.bias.CCA/blob/c85e1e3bfa4e57750a21dea7d61ed12a9c471a61/DESCRIPTION#L19), is [not available on CRAN](https://cran.r-project.org/web/packages/olpsR). However, there is a package of the same name [that is available on GitHub](https://github.com/ngloe/olpsR), and I assume this is the package that was intended.

This PR resolves the issue through use of the `Remotes` field, which `devtools` [understands](https://devtools.r-lib.org/articles/dependencies.html). This will cause 
```
devtools::install_github("nilanjanalaha/de.bias.CCA")
```
to retrieve `olpsR` from GitHub, and installation now succeeds.

As a side note, I'm not sure if `olpsR` is actually a *hard* dependency. The only mention of it I could find in the repo was [this line](https://github.com/nilanjanalaha/de.bias.CCA/blob/c85e1e3bfa4e57750a21dea7d61ed12a9c471a61/R/nodewise_Lasso_preparation_functions.R#L12), which is commented out anyway, so this issue could also be resolved by simply removing the dependency on `olpsR`.