### PR TITLE
Fix CVXR namespace issues

### DIFF
--- a/R/Initializing_nodewise_Lasso.R
+++ b/R/Initializing_nodewise_Lasso.R
@@ -24,13 +24,13 @@ opt_init <- function(l,lam)
 {
   A <- give_approx(l[[1]])
   b <- l[[2]]
-  x <- Variable(length(b))
+  x <- CVXR::Variable(length(b))
 
-  obj <- sum(quad_form(x,A),-t(b)%*%x,lam*abs(x))
-  prob <- Problem(Minimize(obj))
+  obj <- sum(CVXR::quad_form(x,A),-t(b)%*%x,lam*abs(x))
+  prob <- CVXR::Problem(CVXR::Minimize(obj))
 
   # Here we do not have the constraint because we have a convex program
-  result <- solve(prob)
+  result <- CVXR::solve(prob)
 
   val <- result$value # Optimal objective
   gamma <- result$getValue(x) # Optimal variables


### PR DESCRIPTION
I encountered an error when running the "toy example" from the README.

Specifically, I first loaded both `de.bias.cca` and `CVXR` with
```
library(de.bias.cca)
library(CVXR)
```
and then ran each block of code specified in the README. The first two blocks run without error, but when I get to the final block, i.e.,
```
# de-bias
temp <- give_CCA(ha, hb, x, y, elements=1:p)
```
I encounter this error:
```
Error in as.vector(data) : 
  no method for coercing this S4 class to a vector
```

After digging into this, I believe this is happening due to namespace issues with `CVXR`. Specifically, the package relies on functionality exported from CVXR, but its namespace is not attached. Even if the user runs `library(CVXR)` before using the code, they will encounter an error since the S4 generic of `solve` will not be available inside of the package's function closures.

This PR fixes the issue without altering the namespace by prefixing CVXR-related functionality with `CVXR::`

With these changes applied, I am now able to successfully run the toy example (and things are fine even if I **don't** explicitly load the `CVXR` package with `library(CVXR)`.